### PR TITLE
Feature/generic get ws

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.0-b15
+current_version = 5.0.0-b16
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>.*)(?P<build>\d+))?
 serialize = 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Spotcast is compatible with any version since 2024.11.0.
 ### Setup
 
 > [!WARNING]
-> It is highly recommended to set a separate Spotify App for Spotcast, especially for multiple accounts. Spotcast + Spotify Integration can lead to high API request if all combined in the same Authentication Application
+> It is highly recommended to set a separate Spotify App for Spotcast, especially for multiple accounts. Spotcast + Spotify Integration can lead to high API request if all combined in the same Authentication Application.
+
+> [!WARNING]
+> If you need to update your application credentials (changed in secret, new Spotify Application). Please follow [these instructions](https://www.home-assistant.io/integrations/application_credentials/)
 
 There are 2 steps for the setup of an account with spotcast
 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -10,7 +10,6 @@ Constants:
 """
 
 from logging import getLogger
-import asyncio
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -25,7 +25,7 @@ from custom_components.spotcast.config_flow.option_flow_handler import (
     DEFAULT_OPTIONS
 )
 
-__version__ = "5.0.0-b15"
+__version__ = "5.0.0-b16"
 
 
 LOGGER = getLogger(__name__)

--- a/custom_components/spotcast/config_flow/config_flow_handler.py
+++ b/custom_components/spotcast/config_flow/config_flow_handler.py
@@ -117,7 +117,7 @@ class SpotcastFlowHandler(SpotifyFlowHandler, domain=DOMAIN):
             await private_session.async_ensure_token_valid()
             accounts: dict[str, Spotify] = {
                 "public": Spotify(auth=external_api["token"]["access_token"]),
-                "private": Spotify(auth=private_session.token)
+                "private": Spotify(auth=private_session.clean_token)
             }
 
             profiles = {}

--- a/custom_components/spotcast/config_flow/config_flow_handler.py
+++ b/custom_components/spotcast/config_flow/config_flow_handler.py
@@ -147,14 +147,13 @@ class SpotcastFlowHandler(SpotifyFlowHandler, domain=DOMAIN):
 
         await self.async_set_unique_id(current_user["id"])
 
-        self._abort_if_unique_id_configured()
-
         if self.source == SOURCE_REAUTH:
             self._abort_if_unique_id_mismatch(reason="reauth_account_mismatch")
             return self.async_update_reload_and_abort(
-                self._get_reauth_entry(), title=name, data=data
+                self._get_reauth_entry(), title=name, data=self.data
             )
 
+        self._abort_if_unique_id_configured()
         current_entries = self.hass.config_entries.async_entries(DOMAIN)
 
         options = {

--- a/custom_components/spotcast/icons.json
+++ b/custom_components/spotcast/icons.json
@@ -26,6 +26,9 @@
         },
         "play_saved_episodes": {
             "service": "mdi:podcast"
+        },
+        "like_media": {
+            "service": "mdi:music-note-plus"
         }
     }
 }

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -20,5 +20,5 @@
         "spotifyaio>=0.8.8",
         "RapidFuzz>=3.10.1"
     ],
-    "version": "v5.0.0-b15"
+    "version": "v5.0.0-b16"
 }

--- a/custom_components/spotcast/media_player/exceptions.py
+++ b/custom_components/spotcast/media_player/exceptions.py
@@ -28,3 +28,7 @@ class MissingDeviceTypeError(MediaPlayerError):
 
 class UnknownIntegrationError(MediaPlayerError):
     """The integration specified is not known for spotcast"""
+
+
+class MissingActiveDeviceError(MediaPlayerError):
+    """No Active device found for the account provided"""

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -180,7 +180,7 @@ play_custom_context:
   fields:
     media_player:
       name: Media Player
-      required: true
+      required: false
       selector:
         target:
           entity:

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -4,7 +4,7 @@ play_media:
   fields:
     media_player:
       name: Media Player
-      required: true
+      required: false
       selector:
         target:
           entity:
@@ -38,7 +38,7 @@ play_dj:
   fields:
     media_player:
       name: Media Player
-      required: true
+      required: false
       selector:
         target:
           entity:
@@ -92,7 +92,7 @@ play_liked_songs:
   fields:
     media_player:
       name: Media Player
-      required: true
+      required: false
       selector:
         target:
           entity:
@@ -119,7 +119,7 @@ play_saved_episodes:
   fields:
     media_player:
       name: Media Player
-      required: true
+      required: false
       selector:
         target:
           entity:
@@ -146,7 +146,7 @@ play_category:
   fields:
     media_player:
       name: Media Player
-      required: true
+      required: false
       selector:
         target:
           entity:
@@ -219,7 +219,7 @@ play_from_search:
   fields:
     media_player:
       name: Media Player
-      required: true
+      required: false
       selector:
         target:
           entity:

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -301,7 +301,29 @@ add_to_queue:
   fields:
     spotify_uris:
       name: Spotify URIs
-      description: A list of spotify URIs
+      description: A list of Spotify URIs
+      required: true
+      selector:
+        object:
+          uris:
+            - name: URIs
+              selector:
+                text:
+                  multiline: false
+    account:
+      name: Spotify Account
+      description: The id of the spotify account to use. Takes the default account otherwise
+      required: false
+      selector:
+        config_entry:
+          integration: spotcast
+like_media:
+  name: Like Media
+  description: Save a list of Media to your Spotify Library
+  fields:
+    spotify_uris:
+      name: Spotify URIs
+      description: A list of Spotify URIs
       required: true
       selector:
         object:

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -234,12 +234,20 @@ play_from_search:
       selector:
         text:
           multiline: false
-    item_type:
+          required: true
+    item_types:
       name: Item Type
       description: The type of item to return from the search result
       example: album
+      required: true
+      default:
+        - album
+        - artist
+        - playlist
+        - track
       selector:
         select:
+          multiple: true
           options:
             - label: Album
               value: album

--- a/custom_components/spotcast/services/like_media.py
+++ b/custom_components/spotcast/services/like_media.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
 
 from custom_components.spotcast.spotify import SpotifyAccount
-from custom_components.spotcast.utils import get_account_entry, search_account
+from custom_components.spotcast.utils import get_account_entry
 from custom_components.spotcast.spotify.utils import url_to_uri
 
 LOGGER = getLogger(__name__)
@@ -27,11 +27,11 @@ async def async_like_media(hass: HomeAssistant, call: ServiceCall):
     uris = call.data.get("spotify_uris")
     account_id = call.data.get("account")
 
-    if account_id is None:
-        entry = get_account_entry(hass)
-        account_id = entry.entry_id
-        account = await SpotifyAccount.async_from_config_entry(hass, entry)
-    else:
-        account = search_account(hass, account_id)
+    entry = get_account_entry(hass, account_id)
+    LOGGER.debug("Loading Spotify Account for User `%s`", account_id)
+    account = await SpotifyAccount.async_from_config_entry(
+        hass=hass,
+        entry=entry
+    )
 
     await account.async_like_media(uris)

--- a/custom_components/spotcast/services/play_category.py
+++ b/custom_components/spotcast/services/play_category.py
@@ -27,7 +27,7 @@ from custom_components.spotcast.services.utils import (
 LOGGER = getLogger(__name__)
 
 PLAY_CATEGORY_SCHEMA = vol.Schema({
-    vol.Required("media_player"): cv.ENTITY_SERVICE_FIELDS,
+    vol.Optional("media_player"): cv.ENTITY_SERVICE_FIELDS,
     vol.Required("category"): cv.string,
     vol.Optional("account"): cv.string,
     vol.Optional("data"): EXTRAS_SCHEMA,

--- a/custom_components/spotcast/services/play_dj.py
+++ b/custom_components/spotcast/services/play_dj.py
@@ -23,7 +23,7 @@ from custom_components.spotcast.utils import copy_to_dict
 LOGGER = getLogger(__name__)
 
 PLAY_DJ_SCHEMA = vol.Schema({
-    vol.Required("media_player"): cv.ENTITY_SERVICE_FIELDS,
+    vol.Optional("media_player"): cv.ENTITY_SERVICE_FIELDS,
     vol.Optional("account"): cv.string,
     vol.Optional("data"): EXTRAS_SCHEMA,
 })

--- a/custom_components/spotcast/services/play_from_search.py
+++ b/custom_components/spotcast/services/play_from_search.py
@@ -93,6 +93,8 @@ async def async_play_from_search(hass: HomeAssistant, call: ServiceCall):
     query = SearchQuery(search_term, item_types, filters, tags)
     search_result = await account.async_search(query, limit)
 
+    LOGGER.warn(search_result)
+
     call_data = copy_to_dict(call.data)
 
     # remove unwanted items from call data
@@ -137,10 +139,12 @@ def get_best_candidate(
 
     for key in ITEM_TYPE_PRIORITY:
 
-        if key not in search_result:
+        if key not in search_result or len(search_result[key]) == 0:
             continue
 
         items = search_result[key]
+
+        LOGGER.warn(key, items)
 
         candidate = items[0]["name"]
         ratio = fuzz.partial_ratio(search_term, candidate)

--- a/custom_components/spotcast/services/play_from_search.py
+++ b/custom_components/spotcast/services/play_from_search.py
@@ -29,7 +29,7 @@ from custom_components.spotcast.utils import (
 LOGGER = getLogger(__name__)
 
 PLAY_FROM_SEARCH_SCHEMA = vol.Schema({
-    vol.Required("media_player"): cv.ENTITY_SERVICE_FIELDS,
+    vol.Optional("media_player"): cv.ENTITY_SERVICE_FIELDS,
     vol.Required("search_term"): cv.string,
     vol.Required("item_types"): vol.All(
         cv.ensure_list,

--- a/custom_components/spotcast/services/play_from_search.py
+++ b/custom_components/spotcast/services/play_from_search.py
@@ -10,6 +10,8 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util.read_only_dict import ReadOnlyDict
 import voluptuous as vol
+from rapidfuzz import fuzz
+from rapidfuzz.utils import default_process as fuzz_processing
 
 
 from custom_components.spotcast.spotify import SpotifyAccount
@@ -29,9 +31,13 @@ LOGGER = getLogger(__name__)
 PLAY_FROM_SEARCH_SCHEMA = vol.Schema({
     vol.Required("media_player"): cv.ENTITY_SERVICE_FIELDS,
     vol.Required("search_term"): cv.string,
-    vol.Required("item_type"): vol.In(SearchQuery.ALLOWED_ITEM_TYPE),
+    vol.Required("item_types"): vol.All(
+        cv.ensure_list,
+        [vol.In(SearchQuery.ALLOWED_ITEM_TYPE)],
+    ),
     vol.Optional("tags"): vol.All(
-        cv.ensure_list, [vol.In(SearchQuery.ALLOWED_TAGS)]
+        cv.ensure_list,
+        [vol.In(SearchQuery.ALLOWED_TAGS)],
     ),
     vol.Optional("filters"): vol.Schema({
         vol.Optional("album"): cv.string,
@@ -48,6 +54,16 @@ PLAY_FROM_SEARCH_SCHEMA = vol.Schema({
 
 MULTI_ITEMS_TYPE = ("track", "episode")
 
+ITEM_TYPE_PRIORITY = (
+    "artists",
+    "tracks",
+    "albums",
+    "playlists",
+    "audiobooks",
+    "shows",
+    "episodes"
+)
+
 
 async def async_play_from_search(hass: HomeAssistant, call: ServiceCall):
     """Service to start playing media from a search result
@@ -59,58 +75,78 @@ async def async_play_from_search(hass: HomeAssistant, call: ServiceCall):
 
     # extract the data fron the call
     search_term = call.data.get("search_term")
-    item_type = call.data.get("item_type")
+    item_types = call.data.get("item_types")
     tags = call.data.get("tags")
     filters = call.data.get("filters")
     account_id = call.data.get("account")
-    extras = call.data.get("data")
+    extras = call.data.get("data", {})
 
     # sets the limit according to item type or extras limit. Defaults
     # to 20
-    limit = 20
-
-    if item_type not in MULTI_ITEMS_TYPE:
-        limit = 1
-    elif extras is not None and "limit" in extras:
-        limit = extras["limit"]
+    limit = extras.get("limit", 1)
 
     # get account
     entry = get_account_entry(hass, account_id)
     account = await SpotifyAccount.async_from_config_entry(hass, entry)
 
     # build search query
-    query = SearchQuery(search_term, item_type, filters, tags)
-
+    query = SearchQuery(search_term, item_types, filters, tags)
     search_result = await account.async_search(query, limit)
 
     call_data = copy_to_dict(call.data)
 
+    # remove unwanted items from call data
     for key in ("search_term", "item_type", "tags", "filters"):
         if key in call_data:
             call_data.pop(key)
 
-    if item_type in MULTI_ITEMS_TYPE:
-        tracks = [x["uri"] for x in search_result]
-        LOGGER.debug(
-            "Playing %d songs fron search `%s`",
-            len(tracks),
-            search_term,
-        )
+    best_candidate = get_best_candidate(search_term, search_result)
+    items = search_result[best_candidate]
 
-        call_data["tracks"] = tracks
-        service_function = async_play_custom_context
+    context_uri = items[0]["uri"]
+    LOGGER.debug(
+        "Playing uir `%s` as a result of search `%s`",
+        context_uri,
+        search_term
+    )
 
-    else:
-
-        context_uri = search_result[0]["uri"]
-        LOGGER.debug(
-            "Playing uir `%s` as a result of search `%s`",
-            context_uri,
-            search_term
-        )
-
-        call_data["spotify_uri"] = context_uri
-        service_function = async_play_media
+    call_data["spotify_uri"] = context_uri
 
     call.data = ReadOnlyDict(call_data)
-    await service_function(hass, call)
+    await async_play_media(hass, call)
+
+
+def get_best_candidate(
+        search_term: str,
+        search_result: dict[str, list[dict]]
+) -> str:
+    """Returns the best candidate for a search query according to
+    the item in each category provided
+
+    Args:
+        - search_term(str): the term used for the search query
+        - serach_result(dict[str, list[dict]]): the result from the
+            search query
+
+    Returns:
+        - str: returns the item type selected as best candidate
+    """
+
+    best_ratio = 0
+    best_candidate = None
+
+    for key in ITEM_TYPE_PRIORITY:
+
+        if key not in search_result:
+            continue
+
+        items = search_result[key]
+
+        candidate = items[0]["name"]
+        ratio = fuzz.partial_ratio(search_term, candidate)
+
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_candidate = key
+
+    return best_candidate

--- a/custom_components/spotcast/services/play_liked_songs.py
+++ b/custom_components/spotcast/services/play_liked_songs.py
@@ -25,7 +25,7 @@ from custom_components.spotcast.services.utils import (
 LOGGER = getLogger(__name__)
 
 PLAY_LIKED_SONGS_SCHEMA = vol.Schema({
-    vol.Required("media_player"): cv.ENTITY_SERVICE_FIELDS,
+    vol.Optional("media_player"): cv.ENTITY_SERVICE_FIELDS,
     vol.Optional("account"): cv.string,
     vol.Optional("data"): EXTRAS_SCHEMA,
 })

--- a/custom_components/spotcast/services/play_media.py
+++ b/custom_components/spotcast/services/play_media.py
@@ -88,6 +88,10 @@ async def async_play_media(hass: HomeAssistant, call: ServiceCall):
     elif (playback_state := await account.async_playback_state(force=True))\
             != {}:
         media_player = SpotifyDevice(account, playback_state["device"])
+    else:
+        raise ServiceValidationError(
+            "No active playback available. Provide a target"
+        )
 
     LOGGER.info(
         "Playing `%s` on `%s` for account `%s`",

--- a/custom_components/spotcast/services/play_saved_episodes.py
+++ b/custom_components/spotcast/services/play_saved_episodes.py
@@ -27,7 +27,7 @@ from custom_components.spotcast.services.utils import (
 LOGGER = getLogger(__name__)
 
 PLAY_SAVED_EPISODES = vol.Schema({
-    vol.Required("media_player"): cv.ENTITY_SERVICE_FIELDS,
+    vol.Optional("media_player"): cv.ENTITY_SERVICE_FIELDS,
     vol.Optional("account"): cv.string,
     vol.Optional("data"): EXTRAS_SCHEMA,
 })

--- a/custom_components/spotcast/services/transfer_playback.py
+++ b/custom_components/spotcast/services/transfer_playback.py
@@ -55,10 +55,8 @@ async def async_transfer_playback(hass: HomeAssistant, call: ServiceCall):
 
     # check if no active playback
     if playback_state == {} and account.last_playback_state == {}:
-        raise ServiceValidationError(
-            f"Account `{account.name}` has no known or active playback. "
-            "Nothing to transfer"
-        )
+        LOGGER.warning("No known playback state. Defaults back to liked songs")
+        call_data["spotify_uri"] = account.liked_songs_uri
     elif playback_state != {}:
         call_data["spotify_uri"] = None
     else:

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -1025,7 +1025,7 @@ class SpotifyAccount:
     async def async_view(
         self,
         url: str,
-        locale: str,
+        language: str = None,
         limit: int = None,
     ) -> list[dict]:
         """Fetches a view based on url.
@@ -1033,8 +1033,10 @@ class SpotifyAccount:
         Args:
             - url(str): The url of the view to fetch (e.g.,
                 'made-for-x').
-            - locale(str): The locale for the request (optional).
-            - limit(int, None): The maximum number of playlists to
+            - language(str, optional): The ISO-639-1 language code to
+                show the view in. If None, defaults to en_US. Default
+                is None.
+            - limit(int, optional): The maximum number of playlists to
                 retrieve. If None, retrieves all items. Defaults to
                 None.
 
@@ -1043,6 +1045,8 @@ class SpotifyAccount:
         """
 
         await self.async_ensure_tokens_valid()
+
+        locale = None if language is None else f"{language}_{self.country}"
 
         return await self._async_pager(
             function=self._fetch_view,

--- a/custom_components/spotcast/spotify/search_query.py
+++ b/custom_components/spotcast/spotify/search_query.py
@@ -37,23 +37,23 @@ class SearchQuery:
     def __init__(
             self,
             search: str,
-            item_type: str,
+            item_types: str | list[str],
             filters: dict[str, str] = None,
             tags: list[str] = None,
     ):
 
-        if filters is None:
-            filters = {}
-
-        if tags is None:
-            tags = []
+        filters = {} if filters is None else filters
+        tags = [] if tags is None else tags
+        item_types = item_types if isinstance(item_types, list) else [
+            item_types
+        ]
 
         self.raise_on_invalid_filters(filters)
         self.raise_on_invalid_tags(tags)
-        self.raise_on_invalid_item_type(item_type)
+        self.raise_on_invalid_item_type(item_types)
 
         self.search = search
-        self.item_type = item_type
+        self.item_types = item_types
         self.filters = filters
         self.tags = tags
 
@@ -73,15 +73,22 @@ class SearchQuery:
 
         return query
 
+    @property
+    def item_types_string(self) -> str:
+        """Returns the string for the item_types to search"""
+        return ','.join(self.item_types)
+
     @classmethod
-    def raise_on_invalid_item_type(cls, item_type: str):
+    def raise_on_invalid_item_type(cls, item_types: list[str]):
         """Raises an InvalidItemTypeError if an invalid item time
         was provided"""
-        if item_type not in cls.ALLOWED_ITEM_TYPE:
-            raise InvalidItemTypeError(
-                f"`{item_type}` is not a valid item type. Must be part of "
-                f"{cls.ALLOWED_ITEM_TYPE}"
-            )
+
+        for item_type in item_types:
+            if item_type not in cls.ALLOWED_ITEM_TYPE:
+                raise InvalidItemTypeError(
+                    f"`{item_type}` is not a valid item type. Must be part of "
+                    f"{cls.ALLOWED_ITEM_TYPE}"
+                )
 
     @classmethod
     def raise_on_invalid_filters(cls, filters: dict[str, str]):

--- a/custom_components/spotcast/strings.json
+++ b/custom_components/spotcast/strings.json
@@ -1,12 +1,4 @@
 {
-    "common": {
-        "media_player_name": "Media Player",
-        "media_player_desc": "A Single Media Player compatible with Spotcast",
-        "account_name": "Spotify Account",
-        "account_desc": "The id of the Spotify account to use. Takes the default account otherwise.",
-        "data_name": "Data",
-        "data_desc": "Additional modifiers when starting media playback"
-    },
     "config": {
         "step": {
             "internal_api": {
@@ -54,8 +46,22 @@
                     "description": "A list of track to add to the active playback"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
+                }
+            }
+        },
+        "like_media": {
+            "name": "Like Media",
+            "description": "Add a list of media to your Spotify Library",
+            "fields": {
+                "spotify_uris": {
+                    "name": "Spotify URIs",
+                    "description": "A list of track to add to the active playback"
+                },
+                "account": {
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 }
             }
         },
@@ -64,20 +70,20 @@
             "description": "Plays a random playlist from a Browse Category",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "category": {
                     "name": "Category",
                     "description": "A Category name or ID. A fuzzy match is applied on the name, but an ID must be an exact match."
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -86,20 +92,20 @@
             "description": "Starts playback from a custom list of tracks URIs",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "items": {
                     "name": "Items",
                     "description": "A list of track URIs."
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -108,16 +114,16 @@
             "description": "Play Spotify DJ playlist on a Chromecast device",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -126,8 +132,8 @@
             "description": "Start playback from a search result",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "search_term": {
                     "name": "Search Term",
@@ -146,12 +152,12 @@
                     "description": "Filters to apply to the search query."
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -160,16 +166,16 @@
             "description": "Play User's Liked Songs",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -178,20 +184,20 @@
             "description": "Play Spotify media on Chromecast devices",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "spotify_uri": {
                     "name": "URI",
                     "description": "Supported Spotify URI or URL"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -200,16 +206,16 @@
             "description": "Play User's Saved Podcast Episodes",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -218,16 +224,16 @@
             "description": "Transfers the Spotify playback to the targeted device",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         }

--- a/custom_components/spotcast/translations/en.json
+++ b/custom_components/spotcast/translations/en.json
@@ -1,12 +1,4 @@
 {
-    "common": {
-        "media_player_name": "Media Player",
-        "media_player_desc": "A Single Media Player compatible with Spotcast",
-        "account_name": "Spotify Account",
-        "account_desc": "The id of the Spotify account to use. Takes the default account otherwise.",
-        "data_name": "Data",
-        "data_desc": "Additional modifiers when starting media playback"
-    },
     "config": {
         "step": {
             "internal_api": {
@@ -54,8 +46,8 @@
                     "description": "A list of track to add to the active playback"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 }
             }
         },
@@ -64,20 +56,20 @@
             "description": "Plays a random playlist from a Browse Category",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "category": {
                     "name": "Category",
                     "description": "A Category name or ID. A fuzzy match is applied on the name, but an ID must be an exact match."
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -86,20 +78,20 @@
             "description": "Starts playback from a custom list of tracks URIs",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "items": {
                     "name": "Items",
                     "description": "A list of track URIs."
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -108,16 +100,16 @@
             "description": "Play Spotify DJ playlist on a Chromecast device",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -126,8 +118,8 @@
             "description": "Start playback from a search result",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "search_term": {
                     "name": "Search Term",
@@ -146,12 +138,12 @@
                     "description": "Filters to apply to the search query."
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -160,16 +152,16 @@
             "description": "Play User's Liked Songs",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -178,20 +170,20 @@
             "description": "Play Spotify media on Chromecast devices",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "spotify_uri": {
                     "name": "URI",
                     "description": "Supported Spotify URI or URL"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -200,16 +192,16 @@
             "description": "Play User's Saved Podcast Episodes",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         },
@@ -218,16 +210,16 @@
             "description": "Transfers the Spotify playback to the targeted device",
             "fields": {
                 "media_player": {
-                    "name": "[%key:compoment::spotcast::common::media_player_name%]",
-                    "description": "[%key:compoment::spotcast::common::media_player_desc%]"
+                    "name": "Target",
+                    "description": "A Single Media Player compatible with Spotcast"
                 },
                 "account": {
-                    "name": "[%key:compoment::spotcast::common::account_name%]",
-                    "description": "[%key:compoment::spotcast::common::account_desc%]"
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
                 },
                 "data": {
-                    "name": "[%key:compoment::spotcast::common::data_name%]",
-                    "description": "[%key:compoment::spotcast::common::data_desc%]"
+                    "name": "Data",
+                    "description": "Additional modifiers when starting media playback"
                 }
             }
         }

--- a/custom_components/spotcast/translations/en.json
+++ b/custom_components/spotcast/translations/en.json
@@ -51,6 +51,20 @@
                 }
             }
         },
+        "like_media": {
+            "name": "Like Media",
+            "description": "Add a list of media to your Spotify Library",
+            "fields": {
+                "spotify_uris": {
+                    "name": "Spotify URIs",
+                    "description": "A list of track to add to the active playback"
+                },
+                "account": {
+                    "name": "Spotify Account",
+                    "description": "The id of the Spotify account to use. Takes the default account otherwise."
+                }
+            }
+        },
         "play_category": {
             "name": "Playlist from Category",
             "description": "Plays a random playlist from a Browse Category",

--- a/custom_components/spotcast/websocket/categories_handler.py
+++ b/custom_components/spotcast/websocket/categories_handler.py
@@ -5,10 +5,11 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.core import HomeAssistant
 from homeassistant.components.websocket_api import ActiveConnection
 
-from custom_components.spotcast.utils import get_account_entry, search_account
-from custom_components.spotcast.spotify.account import SpotifyAccount
-from custom_components.spotcast.websocket.utils import websocket_wrapper
 from custom_components.spotcast.spotify.utils import select_image_url
+from custom_components.spotcast.websocket.utils import (
+    websocket_wrapper,
+    async_get_account,
+)
 
 ENDPOINT = "spotcast/categories"
 SCHEMA = vol.Schema({
@@ -36,14 +37,8 @@ async def async_get_categories(
 
     account_id = msg.get("account")
     limit = msg.get("limit")
-    account: SpotifyAccount
 
-    if account_id is None:
-        entry = get_account_entry(hass)
-        account_id = entry.entry_id
-        account = await SpotifyAccount.async_from_config_entry(hass, entry)
-    else:
-        account = search_account(hass, account_id)
+    account = await async_get_account(hass, account_id)
 
     raw_categories = await account.async_categories(limit=limit)
 
@@ -61,7 +56,7 @@ async def async_get_categories(
         msg["id"],
         {
             "total": len(categories),
-            "account": account_id,
+            "account": account.id,
             "categories": categories
         },
     )

--- a/custom_components/spotcast/websocket/devices_handler.py
+++ b/custom_components/spotcast/websocket/devices_handler.py
@@ -5,9 +5,10 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.core import HomeAssistant
 from homeassistant.components.websocket_api import ActiveConnection
 
-from custom_components.spotcast.utils import get_account_entry, search_account
-from custom_components.spotcast.spotify.account import SpotifyAccount
-from custom_components.spotcast.websocket.utils import websocket_wrapper
+from custom_components.spotcast.websocket.utils import (
+    websocket_wrapper,
+    async_get_account,
+)
 
 ENDPOINT = "spotcast/devices"
 SCHEMA = vol.Schema({
@@ -33,14 +34,8 @@ async def async_get_devices(
     """
 
     account_id = msg.get("account")
-    account: SpotifyAccount
 
-    if account_id is None:
-        entry = get_account_entry(hass)
-        account_id = entry.entry_id
-        account = await SpotifyAccount.async_from_config_entry(hass, entry)
-    else:
-        account = search_account(hass, account_id)
+    account = await async_get_account(hass, account_id)
 
     devices = await account.async_devices(force=True)
 
@@ -48,7 +43,7 @@ async def async_get_devices(
         msg["id"],
         {
             "total": len(devices),
-            "account": account_id,
+            "account": account.id,
             "devices": devices
         },
     )

--- a/custom_components/spotcast/websocket/liked_media_handler.py
+++ b/custom_components/spotcast/websocket/liked_media_handler.py
@@ -3,9 +3,10 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.core import HomeAssistant
 from homeassistant.components.websocket_api import ActiveConnection
 
-from custom_components.spotcast.utils import get_account_entry, search_account
-from custom_components.spotcast.spotify.account import SpotifyAccount
-from custom_components.spotcast.websocket.utils import websocket_wrapper
+from custom_components.spotcast.websocket.utils import (
+    websocket_wrapper,
+    async_get_account,
+)
 
 ENDPOINT = "spotcast/liked_media"
 SCHEMA = vol.Schema(
@@ -30,14 +31,7 @@ async def async_liked_media(
     """
     account_id = msg.get("account")
 
-    account: SpotifyAccount
-
-    if account_id is None:
-        entry = get_account_entry(hass)
-        account_id = entry.entry_id
-        account = await SpotifyAccount.async_from_config_entry(hass, entry)
-    else:
-        account = search_account(hass, account_id)
+    account = await async_get_account(hass, account_id)
 
     liked_media = await account.async_liked_songs()
 
@@ -45,7 +39,7 @@ async def async_liked_media(
         msg["id"],
         {
             "total": len(liked_media),
-            "account": account_id,
+            "account": account.id,
             "tracks": liked_media,
         },
     )

--- a/custom_components/spotcast/websocket/player_handler.py
+++ b/custom_components/spotcast/websocket/player_handler.py
@@ -5,9 +5,10 @@ from homeassistant.components.websocket_api import ActiveConnection
 import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 
-from custom_components.spotcast.utils import get_account_entry, search_account
-from custom_components.spotcast.spotify.account import SpotifyAccount
-from custom_components.spotcast.websocket.utils import websocket_wrapper
+from custom_components.spotcast.websocket.utils import (
+    websocket_wrapper,
+    async_get_account,
+)
 
 ENDPOINT = "spotcast/player"
 SCHEMA = vol.Schema({
@@ -33,21 +34,15 @@ async def async_get_playback(
     """
 
     account_id = msg.get("account")
-    account: SpotifyAccount
 
-    if account_id is None:
-        entry = get_account_entry(hass)
-        account_id = entry.entry_id
-        account = await SpotifyAccount.async_from_config_entry(hass, entry)
-    else:
-        account = search_account(hass, account_id)
+    account = await async_get_account(hass, account_id)
 
     playback_state = await account.async_playback_state(force=True)
 
     connection.send_result(
         msg["id"],
         {
-            "account": account_id,
+            "account": account.id,
             "state": playback_state,
         },
     )

--- a/custom_components/spotcast/websocket/utils.py
+++ b/custom_components/spotcast/websocket/utils.py
@@ -4,6 +4,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.exceptions import ServiceValidationError, HomeAssistantError
 
+from custom_components.spotcast.spotify.account import SpotifyAccount
+from custom_components.spotcast.utils import get_account_entry, search_account
+
 HANDLED_EXCEPTIONS = (ServiceValidationError, HomeAssistantError)
 
 
@@ -20,3 +23,23 @@ def websocket_wrapper(func: callable):
             connection.send_error(msg["id"], type(exc).__name__, str(exc))
 
     return wrapper
+
+
+async def async_get_account(hass: HomeAssistant, account: str = None) -> SpotifyAccount:
+    """Retrieves a spotify account for a websocket query
+
+    Args:
+        - hass(HomeAssistant): the Home Assistant Instance
+        - account_id(str, optional): the account to retrieve. Either
+            an entry ud or an account id or name. If None, retrives the
+            default account. Defaults to None.
+
+    Return:
+        - SpotifyAccount: A spotify account
+    """
+
+    if account is not None:
+        return search_account(hass, account)
+
+    entry = get_account_entry(hass)
+    return await SpotifyAccount.async_from_config_entry(hass, entry)

--- a/docs/services/play_from_search.md
+++ b/docs/services/play_from_search.md
@@ -10,7 +10,8 @@ data:
     media_player:
         entity_id: media_player.foo
     search_term: Taman Shud
-    item_type: track
+    item_types:
+        - track
     filters:
         artist: The Drones
         album: Feelin Kinda Free
@@ -26,9 +27,11 @@ Let the user select a compatible device on which to start the playback. **_Must 
 
 ### `search_term` (str)
 
-*optional*
-
 A generic search term that could be for any type of items
+
+### item_types (list[str])
+
+A list of item types to look for in the search query.
 
 ### `tags` (list[str])
 

--- a/test/config_flow/config_flow_handler/__init__.py
+++ b/test/config_flow/config_flow_handler/__init__.py
@@ -1,0 +1,1 @@
+TEST_MODULE = "custom_components.spotcast.config_flow.config_flow_handler"

--- a/test/config_flow/config_flow_handler/test_async_oauth_create_entry.py
+++ b/test/config_flow/config_flow_handler/test_async_oauth_create_entry.py
@@ -4,12 +4,14 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import AbortFlow
 
 from custom_components.spotcast.config_flow.config_flow_handler import (
     SpotcastFlowHandler,
     SOURCE_REAUTH,
     Spotify,
     PrivateSession,
+    ConfigEntry,
 )
 
 from test.config_flow.config_flow_handler import TEST_MODULE
@@ -225,6 +227,197 @@ class TestPublicPrivateProfileMismatch(IsolatedAsyncioTestCase):
 
     def test_abort_correctly_called(self):
         try:
-            self.handler.async_abort(reason="public_private_accounts_mismatch")
+            self.handler.async_abort.assert_called_with(
+                reason="public_private_accounts_mismatch"
+            )
         except AssertionError:
             self.fail()
+
+
+class TestReauthProcess(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.Spotify", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.PrivateSession", new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_private: MagicMock,
+        mock_spotify: MagicMock,
+    ):
+
+        mock_private.return_value = MagicMock(spec=PrivateSession)
+        mock_spotify.return_value = MagicMock(spec=Spotify)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "private": mock_private.return_value,
+            "spotify": mock_spotify.return_value,
+            "entry": MagicMock(spec=ConfigEntry)
+        }
+
+        self.mocks["entry"].unique_id = "foo"
+        self.mocks["private"].token = "23456"
+        self.mocks["hass"].async_add_executor_job = AsyncMock(side_effect=[
+            {
+                "id": "foo",
+            },
+            {
+                "id": "foo",
+            }
+        ])
+
+        self.data = {
+            "external_api": {
+                "token": {
+                    "access_token": "12345"
+                }
+            },
+            "internal_api": {
+                "sp_dc": "foo",
+                "sp_key": "bar",
+            }
+        }
+
+        self.handler = SpotcastFlowHandler()
+        self.handler.hass = self.mocks["hass"]
+        self.handler.data = self.data
+        self.handler.context = {
+            "source": SOURCE_REAUTH,
+            "unique_id": "foo"
+        }
+        self.handler._get_reauth_entry = MagicMock(
+            return_value=self.mocks["entry"]
+        )
+        self.handler.async_update_reload_and_abort = MagicMock()
+
+        self.result = await self.handler.async_oauth_create_entry({})
+
+    def test_abort_correctly_called(self):
+        try:
+            self.handler.async_update_reload_and_abort.assert_called_with(
+                self.mocks["entry"],
+                title="foo",
+                data=self.handler.data,
+            )
+        except AssertionError:
+            self.fail()
+
+
+class TestFailReauthProcess(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.Spotify", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.PrivateSession", new_callable=MagicMock)
+    async def test_error_raised(
+        self,
+        mock_private: MagicMock,
+        mock_spotify: MagicMock,
+    ):
+
+        mock_private.return_value = MagicMock(spec=PrivateSession)
+        mock_spotify.return_value = MagicMock(spec=Spotify)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "private": mock_private.return_value,
+            "spotify": mock_spotify.return_value,
+            "entry": MagicMock(spec=ConfigEntry)
+        }
+
+        self.mocks["entry"].unique_id = "bar"
+        self.mocks["private"].token = "23456"
+        self.mocks["hass"].async_add_executor_job = AsyncMock(side_effect=[
+            {
+                "id": "foo",
+            },
+            {
+                "id": "foo",
+            }
+        ])
+
+        self.data = {
+            "external_api": {
+                "token": {
+                    "access_token": "12345"
+                }
+            },
+            "internal_api": {
+                "sp_dc": "foo",
+                "sp_key": "bar",
+            }
+        }
+
+        self.handler = SpotcastFlowHandler()
+        self.handler.hass = self.mocks["hass"]
+        self.handler.data = self.data
+        self.handler.context = {
+            "source": SOURCE_REAUTH,
+            "unique_id": "bar"
+        }
+        self.handler._get_reauth_entry = MagicMock(
+            return_value=self.mocks["entry"]
+        )
+        self.handler.async_update_reload_and_abort = MagicMock()
+
+        with self.assertRaises(AbortFlow):
+            await self.handler.async_oauth_create_entry({})
+
+
+class TestUniqueIdExist(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.Spotify", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.PrivateSession", new_callable=MagicMock)
+    async def test_error_raised(
+        self,
+        mock_private: MagicMock,
+        mock_spotify: MagicMock,
+    ):
+
+        mock_private.return_value = MagicMock(spec=PrivateSession)
+        mock_spotify.return_value = MagicMock(spec=Spotify)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "private": mock_private.return_value,
+            "spotify": mock_spotify.return_value,
+            "entry": MagicMock(spec=ConfigEntry)
+        }
+
+        self.mocks["entry"].unique_id = "bar"
+        self.mocks["private"].token = "23456"
+        self.mocks["hass"].async_add_executor_job = AsyncMock(side_effect=[
+            {
+                "id": "foo",
+            },
+            {
+                "id": "foo",
+            }
+        ])
+
+        self.data = {
+            "external_api": {
+                "token": {
+                    "access_token": "12345"
+                }
+            },
+            "internal_api": {
+                "sp_dc": "foo",
+                "sp_key": "bar",
+            }
+        }
+
+        self.handler = SpotcastFlowHandler()
+        self.handler.hass = self.mocks["hass"]
+        self.handler.data = self.data
+        self.handler.context = {
+            "source": SOURCE_REAUTH,
+            "unique_id": "bar"
+        }
+        self.handler._get_reauth_entry = MagicMock(
+            return_value=self.mocks["entry"]
+        )
+        self.handler.async_update_reload_and_abort = MagicMock()
+        self.handler._abort_if_unique_id_configured = MagicMock(
+            side_effect=AbortFlow(reason="test_abort")
+        )
+
+        with self.assertRaises(AbortFlow):
+            await self.handler.async_oauth_create_entry({})

--- a/test/config_flow/config_flow_handler/test_async_oauth_create_entry.py
+++ b/test/config_flow/config_flow_handler/test_async_oauth_create_entry.py
@@ -3,7 +3,6 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, MagicMock, AsyncMock
 
-from spotipy import Spotify
 from homeassistant.core import HomeAssistant
 
 from custom_components.spotcast.config_flow.config_flow_handler import (
@@ -13,7 +12,7 @@ from custom_components.spotcast.config_flow.config_flow_handler import (
     PrivateSession,
 )
 
-TEST_MODULE = "custom_components.spotcast.config_flow.config_flow_handler"
+from test.config_flow.config_flow_handler import TEST_MODULE
 
 
 class TestExternalApiEntry(IsolatedAsyncioTestCase):
@@ -54,149 +53,66 @@ class TestExternalApiEntry(IsolatedAsyncioTestCase):
             self.fail("internal_api step was never called")
 
 
-class TestInternalApiEntry(IsolatedAsyncioTestCase):
+class TestInternalApiProvided(IsolatedAsyncioTestCase):
 
-    def setUp(self):
+    @patch(f"{TEST_MODULE}.Spotify", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.PrivateSession", new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_private: MagicMock,
+        mock_spotify: MagicMock,
+    ):
 
-        self.external_api = {
-            "auth_implementation": "spotcast_foo",
-            "token": {
-                "access_token": "12345",
-                "token_type": "Bearer",
-                "expires_in": 3600,
-                "refreh_token": "ABCDF",
-                "expires_at": 1729807129.8667192
+        mock_private.return_value = MagicMock(spec=PrivateSession)
+        mock_spotify.return_value = MagicMock(spec=Spotify)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "private": mock_private.return_value,
+            "spotify": mock_spotify.return_value,
+        }
+
+        self.mocks["private"].token = "23456"
+        self.mocks["hass"].async_add_executor_job = AsyncMock(return_value={
+            "id": "foo",
+            "display_name": "User Name"
+        })
+
+        self.data = {
+            "external_api": {
+                "token": {
+                    "access_token": "12345"
+                }
+            },
+            "internal_api": {
+                "sp_dc": "foo",
+                "sp_key": "bar",
             }
         }
 
-        self.internal_api = {
-            "sp_dc": "foo",
-            "sp_key": "bar",
-        }
+        self.handler = SpotcastFlowHandler()
+        self.handler.hass = self.mocks["hass"]
+        self.handler.data = self.data
+        self.handler.async_set_unique_id = AsyncMock()
+        self.handler.async_create_entry = MagicMock()
+        self.mocks["hass"].config_entries.async_entries.return_value = []
 
-        self.flow_handler = SpotcastFlowHandler()
-        self.flow_handler.data = {
-            "external_api": self.external_api,
-            "internal_api": self.internal_api,
-        }
+        self.result = await self.handler.async_oauth_create_entry({})
 
-    @patch.object(SpotcastFlowHandler, "async_set_unique_id")
-    @patch.object(SpotcastFlowHandler, "hass", new_callable=MagicMock)
-    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
-    async def test_spotify_object_created_with_proper_access_token(
-            self,
-            mock_spotify: MagicMock,
-            mock_hass: MagicMock,
-            mock_set_id: AsyncMock,
-    ):
-
-        mock_hass.async_add_executor_job = AsyncMock()
-        mock_hass.async_add_executor_job.return_value = {
-            "id": "foo",
-            "display_name": "Dummy User",
-        }
-
-        mock_hass.config_entries.async_entries = MagicMock(
-            return_value=[
-                "foo"
-            ]
-        )
-
-        await self.flow_handler.async_oauth_create_entry(
-            self.flow_handler.data
-        )
-
+    def test_entry_properly_setup(self):
         try:
-            mock_spotify.assert_called_with("12345")
-        except AssertionError:
-            self.fail("Spotify constructor called with wrong token")
-
-    @patch(f"{TEST_MODULE}.PrivateSession", spec=PrivateSession, new_callable=MagicMock)
-    @patch.object(SpotcastFlowHandler, "async_create_entry")
-    @patch.object(SpotcastFlowHandler, "async_set_unique_id")
-    @patch.object(SpotcastFlowHandler, "hass", new_callable=MagicMock)
-    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
-    async def test_entry_setup_with_expected_data(
-            self,
-            mock_spotify: MagicMock,
-            mock_hass: MagicMock,
-            mock_set_id: AsyncMock,
-            mock_entry: AsyncMock,
-            mock_session: MagicMock,
-    ):
-        mock_session.return_value = MagicMock(spec=PrivateSession)
-        mock_session.return_value.async_ensure_token_valid = AsyncMock()
-
-        mock_hass.async_add_executor_job = AsyncMock()
-        mock_hass.async_add_executor_job.return_value = {
-            "id": "foo",
-            "display_name": "Dummy User",
-        }
-
-        mock_hass.config_entries.async_entries = MagicMock(
-            return_value=[
-                "foo"
-            ]
-        )
-
-        await self.flow_handler.async_oauth_create_entry(
-            self.flow_handler.data
-        )
-
-        data = {
-            "external_api": self.external_api,
-            "internal_api": self.internal_api,
-            "name": "Dummy User"
-        }
-
-        options = {
-            "is_default": False,
-            "base_refresh_rate": 30,
-        }
-
-        try:
-            mock_entry.assert_called_with(
-                title="Dummy User",
-                data=data,
-                options=options,
-            )
-        except AssertionError:
-            self.fail("Wrong arguments provided to entry creation")
-
-    @patch(f"{TEST_MODULE}.PrivateSession", spec=PrivateSession, new_callable=MagicMock)
-    @patch.object(SpotcastFlowHandler, "async_create_entry")
-    @patch.object(SpotcastFlowHandler, "async_set_unique_id")
-    @patch.object(SpotcastFlowHandler, "hass", new_callable=MagicMock)
-    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
-    async def test_name_is_id_when_missing_display_name(
-            self,
-            mock_spotify: MagicMock,
-            mock_hass: MagicMock,
-            mock_set_id: AsyncMock,
-            mock_entry: AsyncMock,
-            mock_session: MagicMock,
-    ):
-
-        mock_session.return_value = MagicMock(spec=PrivateSession)
-        mock_session.return_value.async_ensure_token_valid = AsyncMock()
-        mock_hass.async_add_executor_job = AsyncMock()
-        mock_hass.async_add_executor_job.return_value = {
-            "id": "foo",
-        }
-
-        mock_hass.config_entries.async_entries = MagicMock(return_value=[])
-
-        await self.flow_handler.async_oauth_create_entry(
-            self.flow_handler.data
-        )
-
-        try:
-            mock_entry.assert_called_with(
-                title="foo",
+            self.handler.async_create_entry(
+                title="User Name",
                 data={
-                    "name": "foo",
-                    "external_api": self.external_api,
-                    "internal_api": self.internal_api,
+                    "external_api": {
+                        "token": {
+                            "access_token": "12345"
+                        }
+                    },
+                    "internal_api": {
+                        "sp_dc": "foo",
+                        "sp_key": "bar"
+                    }
                 },
                 options={
                     "is_default": True,
@@ -204,114 +120,111 @@ class TestInternalApiEntry(IsolatedAsyncioTestCase):
                 }
             )
         except AssertionError:
-            self.fail("Wrong arguments provided to entry creation")
+            self.fail()
 
 
-class TestImportOfYamlConfig(IsolatedAsyncioTestCase):
+class TestFailedToGetProfile(IsolatedAsyncioTestCase):
 
-    def setUp(self):
-
-        self.external_api = {
-            "auth_implementation": "spotcast_foo",
-            "token": {
-                "access_token": "12345",
-                "token_type": "Bearer",
-                "expires_in": 3600,
-                "refreh_token": "ABCDF",
-                "expires_at": 1729807129.8667192
-            }
-        }
-
-        self.flow_handler = SpotcastFlowHandler()
-        self.flow_handler.data = {
-            "external_api": self.external_api,
-        }
-        self.flow_handler._import_data = {
-            "sp_dc": "foo",
-            "sp_key": "bar",
-        }
-
-    @patch.object(SpotcastFlowHandler, "async_show_form", new_callable=MagicMock)
-    @patch.object(SpotcastFlowHandler, "async_set_unique_id")
-    @patch.object(SpotcastFlowHandler, "hass", new_callable=MagicMock)
-    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify)
-    async def test_skip_internal_api_form(
-            self,
-            mock_spotify: MagicMock,
-            mock_hass: MagicMock,
-            mock_set_id: AsyncMock,
-            mock_form: MagicMock,
-    ):
-
-        mock_hass.async_add_executor_job.return_value = {
-            "id": "foo",
-            "display_name": "Dummy User",
-        }
-
-        mock_hass.config_entries.async_entries = MagicMock(
-            return_value=[
-                "foo"
-            ]
-        )
-
-        await self.flow_handler.async_oauth_create_entry(
-            self.flow_handler.data
-        )
-
-        try:
-            mock_form.assert_not_called()
-        except AssertionError:
-            self.fail("Spotify constructor called with wrong token")
-
-
-class TestReauthProcess(IsolatedAsyncioTestCase):
-
-    @patch(f"{TEST_MODULE}.PrivateSession", new_callable=MagicMock)
     @patch(f"{TEST_MODULE}.Spotify", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.PrivateSession", new_callable=MagicMock)
     async def asyncSetUp(
-            self,
-            mock_spotify: MagicMock,
-            mock_session: MagicMock,
+        self,
+        mock_private: MagicMock,
+        mock_spotify: MagicMock,
     ):
 
+        mock_private.return_value = MagicMock(spec=PrivateSession)
         mock_spotify.return_value = MagicMock(spec=Spotify)
-        mock_session.return_value = MagicMock(spec=PrivateSession)
 
         self.mocks = {
             "hass": MagicMock(spec=HomeAssistant),
+            "private": mock_private.return_value,
             "spotify": mock_spotify.return_value,
-            "session": mock_session.return_value,
         }
 
-        self.mocks["session"].async_ensure_token_valid = AsyncMock()
-        self.mocks["hass"].async_add_executor_job = AsyncMock()
-        self.mocks["hass"].async_add_executor_job.return_value = {
-            "id": "dummy_user",
-            "name": "Dummy Name"
-        }
+        self.mocks["private"].token = "23456"
+        self.mocks["hass"].async_add_executor_job = AsyncMock(
+            side_effect=ValueError()
+        )
 
-        self.mocks["hass"].config_entries = MagicMock()
-        self.mocks["hass"].config_entries.async_entries = []
-
-        self.handler = SpotcastFlowHandler()
-        self.handler.context = {"source": SOURCE_REAUTH}
-        self.handler.hass = self.mocks["hass"]
-        self.handler._abort_if_unique_id_mismatch = MagicMock()
-        self.handler.async_update_reload_and_abort = MagicMock()
-        self.handler._get_reauth_entry = MagicMock()
-        self.handler.data = {
+        self.data = {
             "external_api": {
                 "token": {
-                    "access_token": "foo"
+                    "access_token": "12345"
                 }
             },
-            "internal_api": {},
+            "internal_api": {
+                "sp_dc": "foo",
+                "sp_key": "bar",
+            }
         }
 
-        await self.handler.async_oauth_create_entry({})
+        self.handler = SpotcastFlowHandler()
+        self.handler.hass = self.mocks["hass"]
+        self.handler.data = self.data
+        self.handler.async_abort = MagicMock()
 
-    async def test_reload_called(self):
+        self.result = await self.handler.async_oauth_create_entry({})
+
+    def test_abort_correctly_called(self):
         try:
-            self.handler.async_update_reload_and_abort.assert_called()
+            self.handler.async_abort(reason="connection_error")
+        except AssertionError:
+            self.fail()
+
+
+class TestPublicPrivateProfileMismatch(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.Spotify", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.PrivateSession", new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_private: MagicMock,
+        mock_spotify: MagicMock,
+    ):
+
+        mock_private.return_value = MagicMock(spec=PrivateSession)
+        mock_spotify.return_value = MagicMock(spec=Spotify)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "private": mock_private.return_value,
+            "spotify": mock_spotify.return_value,
+        }
+
+        self.mocks["private"].token = "23456"
+        self.mocks["hass"].async_add_executor_job = AsyncMock(side_effect=[
+            {
+                "id": "foo",
+                "display_name": "User Name"
+            },
+            {
+                "id": "bar",
+                "display_name": "Different User"
+            }
+        ])
+
+        self.data = {
+            "external_api": {
+                "token": {
+                    "access_token": "12345"
+                }
+            },
+            "internal_api": {
+                "sp_dc": "foo",
+                "sp_key": "bar",
+            }
+        }
+
+        self.handler = SpotcastFlowHandler()
+        self.handler.hass = self.mocks["hass"]
+        self.handler.data = self.data
+        self.handler.async_abort = MagicMock()
+
+        self.result = await self.handler.async_oauth_create_entry({})
+
+    def test_abort_correctly_called(self):
+        try:
+            self.handler.async_abort(reason="public_private_accounts_mismatch")
         except AssertionError:
             self.fail()

--- a/test/media_player/utils/test_async_active_device.py
+++ b/test/media_player/utils/test_async_active_device.py
@@ -1,0 +1,56 @@
+"""Module to test the async_active_device function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock
+
+
+from custom_components.spotcast.media_player.utils import (
+    async_active_device,
+    SpotifyAccount,
+    SpotifyDevice,
+    MissingActiveDeviceError,
+)
+
+
+class TestActiveDeviceExist(IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount)
+        }
+
+        self.mocks["account"].async_playback_state = AsyncMock(return_value={
+            "device": {
+                "id": "12345",
+                "is_active": True,
+                "is_private_session": False,
+                "is_restricted": False,
+                "name": "Dummy Device",
+                "type": "computer",
+                "volume_percent": 59,
+                "supports_volume": True
+            }
+        })
+
+        self.result = await async_active_device(self.mocks["account"])
+
+    def test_device_returned_is_spotify_device(self):
+        self.assertIsInstance(self.result, SpotifyDevice)
+
+    def test_device_id_is_one_of_active_device(self):
+        self.assertEqual(self.result.id, "12345")
+
+
+class TestActiveDeviceDoesntExist(IsolatedAsyncioTestCase):
+
+    async def test_error_raised(self):
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount)
+        }
+
+        self.mocks["account"].async_playback_state = AsyncMock(return_value={})
+
+        with self.assertRaises(MissingActiveDeviceError):
+            await async_active_device(self.mocks["account"])

--- a/test/media_player/utils/test_async_media_player_from_id.py
+++ b/test/media_player/utils/test_async_media_player_from_id.py
@@ -9,7 +9,8 @@ from custom_components.spotcast.media_player.utils import (
     SpotifyDevice,
     HomeAssistant,
     MediaPlayerNotFoundError,
-    SpotifyAccount
+    SpotifyAccount,
+    MediaPlayer,
 )
 
 TEST_MODULE = "custom_components.spotcast.media_player.utils"
@@ -40,8 +41,30 @@ class TestDeviceFound(IsolatedAsyncioTestCase):
             "media_player.bar"
         )
 
-    def test_test(self):
+    def test_media_player_returned(self):
         self.assertIs(self.result, self.mock_device)
+
+
+class TestNoEntityId(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_active_device")
+    async def asyncSetUp(self, mock_device: AsyncMock):
+
+        mock_device.return_value = MagicMock(MediaPlayer)
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount),
+            "hass": MagicMock(spec=HomeAssistant),
+            "device": mock_device.return_value,
+        }
+
+        self.result = await async_media_player_from_id(
+            self.mocks["hass"],
+            self.mocks["account"],
+        )
+
+    def test_proper_device_returned(self):
+        self.assertIs(self.result, self.mocks["device"])
 
 
 class TestDeviceNotFound(IsolatedAsyncioTestCase):

--- a/test/services/like_media/__init__.py
+++ b/test/services/like_media/__init__.py
@@ -1,0 +1,1 @@
+TEST_MODULE = "custom_components.spotcast.services.like_media"

--- a/test/services/like_media/test_async_like_media.py
+++ b/test/services/like_media/test_async_like_media.py
@@ -1,0 +1,44 @@
+"""Module to test the async_like_media function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from custom_components.spotcast.services.like_media import (
+    async_like_media,
+    SpotifyAccount,
+    ServiceCall,
+    HomeAssistant,
+)
+
+from test.services.like_media import TEST_MODULE
+
+
+class TestLikingMedia(IsolatedAsyncioTestCase):
+
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_entry: MagicMock, mock_account: AsyncMock):
+
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "call": MagicMock(spec=ServiceCall),
+            "account": mock_account.return_value,
+        }
+
+        self.mocks["account"].async_like_media = AsyncMock()
+
+        self.mocks["call"].data = {
+            "spotify_uris": ["foo", "bar", "baz"]
+        }
+
+        await async_like_media(self.mocks["hass"], self.mocks["call"])
+
+    def test_like_media_properly_called(self):
+        try:
+            self.mocks["account"].async_like_media.assert_called_with(
+                ["foo", "bar", "baz"]
+            )
+        except AssertionError:
+            self.fail()

--- a/test/services/play_custom_context/test_async_play_custom_context.py
+++ b/test/services/play_custom_context/test_async_play_custom_context.py
@@ -8,6 +8,8 @@ from custom_components.spotcast.services.play_custom_context import (
     HomeAssistant,
     ServiceCall,
     SpotifyAccount,
+    MissingActiveDeviceError,
+    ServiceValidationError,
 )
 from custom_components.spotcast.media_player._abstract_player import (
     MediaPlayer
@@ -147,3 +149,92 @@ class TestPlayContextWithExtras(IsolatedAsyncioTestCase):
             )
         except AssertionError:
             self.fail()
+
+
+class TestPlayContextFromActiveDevice(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_media_player_from_id")
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    async def asyncSetUp(
+            self,
+            mock_account: AsyncMock,
+            mock_entry: MagicMock,
+            mock_media_player: AsyncMock,
+    ):
+
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+        mock_media_player.return_value = MagicMock(spec=MediaPlayer)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "call": MagicMock(spec=ServiceCall),
+            "account": mock_account.return_value,
+            "media_player": mock_media_player.return_value,
+        }
+
+        self.mocks["call"].data = {
+            "tracks": ["foo", "bar"]
+        }
+
+        self.mocks["hass"].data = {}
+        self.mocks["media_player"].id = "12345"
+
+        await async_play_custom_context(
+            self.mocks["hass"],
+            self.mocks["call"],
+        )
+
+    def test_async_play_media_called_properly(self):
+        try:
+            self.mocks["account"].async_play_media.assert_called_with(
+                "12345",
+                uris=["foo", "bar"],
+            )
+        except AssertionError:
+            self.fail()
+
+    def test_apply_extras_called_properly(self):
+        try:
+            self.mocks["account"].async_apply_extras(
+                "12345",
+                None
+            )
+        except AssertionError:
+            self.fail()
+
+
+class TestMissingActiveDevice(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_media_player_from_id")
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    async def test_error_raised(
+            self,
+            mock_account: AsyncMock,
+            mock_entry: MagicMock,
+            mock_media_player: AsyncMock,
+    ):
+
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+        mock_media_player.side_effect = MissingActiveDeviceError()
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "call": MagicMock(spec=ServiceCall),
+            "account": mock_account.return_value,
+            "media_player": mock_media_player.return_value,
+        }
+
+        self.mocks["call"].data = {
+            "tracks": ["foo", "bar"]
+        }
+
+        self.mocks["hass"].data = {}
+        self.mocks["media_player"].id = "12345"
+
+        with self.assertRaises(ServiceValidationError):
+            await async_play_custom_context(
+                self.mocks["hass"],
+                self.mocks["call"],
+            )

--- a/test/services/play_from_search/__init__.py
+++ b/test/services/play_from_search/__init__.py
@@ -1,0 +1,1 @@
+TEST_MODULE = "custom_components.spotcast.services.play_from_search"

--- a/test/services/play_from_search/test_get_best_candidate.py
+++ b/test/services/play_from_search/test_get_best_candidate.py
@@ -1,0 +1,49 @@
+"""Module to test the get_best_candidate_function"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from custom_components.spotcast.services.play_from_search import (
+    get_best_candidate
+)
+
+
+class TestCandidateBasedOnFit(TestCase):
+
+    def setUp(self):
+
+        self.search_result = {
+            "artists": [
+                {"name": "foo"}
+            ],
+            "albums": [
+                {"name": "bar"}
+            ]
+        }
+
+        self.result = get_best_candidate("foo", self.search_result)
+
+    def test_proper_result_selected(self):
+        self.assertEqual(self.result, "artists")
+
+
+class TestCandidateBasedOnType(TestCase):
+
+    def setUp(self):
+
+        self.search_result = {
+            "artists": [
+                {"name": "foo"}
+            ],
+            "albums": [
+                {"name": "foo"}
+            ],
+            "tracks": [
+                {"name": "foo"}
+            ]
+        }
+
+        self.result = get_best_candidate("foo", self.search_result)
+
+    def test_proper_result_selected(self):
+        self.assertEqual(self.result, "artists")

--- a/test/services/play_media/test_async_play_media.py
+++ b/test/services/play_media/test_async_play_media.py
@@ -2,11 +2,14 @@
 
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, AsyncMock, patch
+
 from custom_components.spotcast.services.play_media import (
     async_play_media,
     HomeAssistant,
     ServiceCall,
     SpotifyAccount,
+    ServiceValidationError,
+    MissingActiveDeviceError,
 )
 
 TEST_MODULE = "custom_components.spotcast.services.play_media"
@@ -290,3 +293,88 @@ class TestRandomOffsetRequested(IsolatedAsyncioTestCase):
             )
         except AssertionError:
             self.fail()
+
+
+class TestActiveDevicePlayback(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_media_player_from_id")
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_entry: MagicMock,
+        mock_account: AsyncMock,
+        mock_player: AsyncMock,
+    ):
+
+        mock_entry.return_value = MagicMock()
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+        mock_player.return_value.id = "12345"
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "call": MagicMock(spec=ServiceCall),
+            "entry": mock_entry(),
+            "account": mock_account.return_value,
+            "player": mock_player(),
+        }
+
+        self.mocks["call"].data = {
+            "spotify_uri": "dummy_uri",
+            "account": "12345",
+            "data": {
+                "volume": 80
+            }
+        }
+
+        await async_play_media(self.mocks["hass"], self.mocks["call"])
+
+    def test_account_play_media_called_with_expected_arguments(self):
+        try:
+            self.mocks["account"].async_play_media\
+                .assert_called_with("12345", "dummy_uri", volume=80)
+        except AssertionError:
+            self.fail()
+
+    def test_account_apply_extra_called(self):
+        try:
+            self.mocks["account"].async_apply_extras\
+                .assert_called()
+        except AssertionError:
+            self.fail()
+
+
+class TestMissingActiveDevice(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_media_player_from_id")
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    async def test_error_raised(
+        self,
+        mock_entry: MagicMock,
+        mock_account: AsyncMock,
+        mock_player: AsyncMock,
+    ):
+
+        mock_entry.return_value = MagicMock()
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+        mock_player.side_effect = MissingActiveDeviceError()
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "call": MagicMock(spec=ServiceCall),
+            "entry": mock_entry(),
+            "account": mock_account.return_value,
+            "player": mock_player(),
+        }
+
+        self.mocks["call"].data = {
+            "spotify_uri": "dummy_uri",
+            "account": "12345",
+            "data": {
+                "volume": 80
+            }
+        }
+
+        with self.assertRaises(ServiceValidationError):
+            await async_play_media(self.mocks["hass"], self.mocks["call"])

--- a/test/spotify/account/test_async_like_media.py
+++ b/test/spotify/account/test_async_like_media.py
@@ -1,0 +1,68 @@
+"""Module to test the async_like_media function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, patch, AsyncMock
+from time import time
+
+from custom_components.spotcast.spotify.account import (
+    SpotifyAccount,
+    PublicSession,
+    PrivateSession,
+    HomeAssistant,
+    Spotify,
+)
+
+from test.spotify.account import TEST_MODULE
+
+
+class TestLikeSongs(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def asyncSetUp(
+            self,
+            mock_spotify: MagicMock,
+    ):
+
+        self.mocks = {
+            "internal": MagicMock(spec=PrivateSession),
+            "external": MagicMock(spec=PublicSession),
+            "hass": MagicMock(spec=HomeAssistant),
+        }
+        self.mocks["hass"].loop = MagicMock()
+
+        self.mock_spotify = mock_spotify
+
+        self.mocks["external"].token = {
+            "access_token": "12345",
+            "expires_at": 12345.61,
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+            is_default=True
+        )
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock()
+
+        self.account._datasets["liked_songs"].expires_at = 9999
+
+        self.result = await self.account.async_like_media([
+            "foo",
+            "bar",
+            "baz",
+        ])
+
+    def test_executor_properly_called(self):
+        try:
+            self.mocks["hass"].async_add_executor_job.assert_called_with(
+                self.account.apis["private"].current_user_saved_tracks_add,
+                ["foo", "bar", "baz"]
+            )
+        except AssertionError:
+            self.fail()
+
+    def test_liked_songs_dataset_set_to_expired(self):
+        self.assertEqual(self.account._datasets["liked_songs"].expires_at, 0)

--- a/test/spotify/account/test_async_search.py
+++ b/test/spotify/account/test_async_search.py
@@ -40,48 +40,14 @@ class TestSearchQuery(IsolatedAsyncioTestCase):
 
         self.query = SearchQuery(
             search="foo",
-            item_type="artist",
+            item_types="artist",
+        )
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock(
+            return_value={"artists": {"items": ["foo", "bar", "baz"]}}
         )
 
         self.result = await self.account.async_search(self.query)
 
     def test_proper_result_provided(self):
-        self.assertEqual(self.result, ["foo", "bar", "baz"])
-
-
-class TestHighMaxItems(IsolatedAsyncioTestCase):
-
-    @patch.object(SpotifyAccount, "_async_pager")
-    async def asyncSetUp(self, mock_pager: AsyncMock):
-
-        self.mocks = {
-            "hass": MagicMock(spec=HomeAssistant),
-            "external": MagicMock(spec=PublicSession),
-            "internal": MagicMock(spec=PrivateSession),
-            "pager": mock_pager,
-        }
-
-        self.mocks["pager"].return_value = ["foo", "bar", "baz"]
-
-        self.account = SpotifyAccount(
-            entry_id="12345",
-            hass=self.mocks["hass"],
-            public_session=self.mocks["external"],
-            private_session=self.mocks["internal"],
-            is_default=True
-        )
-
-        self.account._datasets["profile"].expires_at = time() + 999
-        self.account._datasets["profile"]._data = {
-            "country": "CA"
-        }
-
-        self.query = SearchQuery(
-            search="foo",
-            item_type="artist",
-        )
-
-        self.result = await self.account.async_search(self.query, max_items=60)
-
-    def test_proper_result_provided(self):
-        self.assertEqual(self.result, ["foo", "bar", "baz"])
+        self.assertEqual(self.result, {"artists": ["foo", "bar", "baz"]})

--- a/test/spotify/account/test_async_view.py
+++ b/test/spotify/account/test_async_view.py
@@ -44,7 +44,7 @@ class TestPlaylistRetrieval(IsolatedAsyncioTestCase):
         try:
             self.mocks["pager"].assert_called_with(
                 function=self.account._fetch_view,
-                prepends=["foo", "fr"],
+                prepends=["foo", "fr_CA"],
                 limit=25,
                 max_items=None,
                 sub_layer="content",

--- a/test/spotify/account/test_async_view.py
+++ b/test/spotify/account/test_async_view.py
@@ -1,0 +1,56 @@
+"""Module to test the async_view function"""
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+from time import time
+
+from custom_components.spotcast.spotify.account import (
+    SpotifyAccount,
+    HomeAssistant,
+    PublicSession,
+    PrivateSession,
+)
+
+
+class TestPlaylistRetrieval(IsolatedAsyncioTestCase):
+
+    @patch.object(SpotifyAccount, "async_ensure_tokens_valid")
+    @patch.object(SpotifyAccount, "_async_pager")
+    async def asyncSetUp(self, mock_pager: AsyncMock, mock_ensure: AsyncMock):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "external": MagicMock(spec=PublicSession),
+            "internal": MagicMock(spec=PrivateSession),
+            "pager": mock_pager,
+        }
+
+        self.mocks["pager"].return_value = ["foo", "bar", "baz"]
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+        )
+        self.account._datasets["profile"] = MagicMock()
+        self.account._datasets["profile"].expires_at = time() + 9999
+        self.account._datasets["profile"].data = {
+            "country": "CA"
+        }
+
+        self.result = await self.account.async_view("foo", "fr")
+
+    def test_pager_properly_called(self):
+        try:
+            self.mocks["pager"].assert_called_with(
+                function=self.account._fetch_view,
+                prepends=["foo", "fr"],
+                limit=25,
+                max_items=None,
+                sub_layer="content",
+            )
+        except AssertionError:
+            self.fail()
+
+    def test_expected_result_returned(self):
+        self.assertEqual(self.result, ["foo", "bar", "baz"])

--- a/test/spotify/account/test_fetch_view.py
+++ b/test/spotify/account/test_fetch_view.py
@@ -1,0 +1,61 @@
+"""Module to test the fetch_view function"""
+from unittest import TestCase
+from unittest.mock import MagicMock
+from time import time
+
+from custom_components.spotcast.spotify.account import (
+    SpotifyAccount,
+    HomeAssistant,
+    PublicSession,
+    PrivateSession,
+)
+
+
+class TestPlaylistRetrieval(TestCase):
+
+    def setUp(self):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "external": MagicMock(spec=PublicSession),
+            "internal": MagicMock(spec=PrivateSession),
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+        )
+        self.account._datasets["profile"] = MagicMock()
+        self.account._datasets["profile"].expires_at = time() + 9999
+        self.account._datasets["profile"].data = {
+            "country": "CA"
+        }
+
+        self.account.apis["private"] = MagicMock()
+        self.account.apis["private"]._get.return_value = ["foo", "bar", "baz"]
+
+        self.result = self.account._fetch_view("content/foo", "fr")
+
+    def test_proper_call_to_get(self):
+        try:
+            self.account.apis["private"]._get.assert_called_with(
+                "content/foo",
+                {
+                    "content_limit": 25,
+                    "locale": "fr",
+                    "platform": "web",
+                    "types": "album,playlist,artist,show,station",
+                    "limit": 25,
+                    "offset": 0,
+                }
+            )
+        except AssertionError:
+            self.fail()
+
+    def test_expected_reply_returned(self):
+        self.assertEqual(
+            self.result,
+            ["foo", "bar", "baz"],
+        )

--- a/test/spotify/search_query/test_constructor.py
+++ b/test/spotify/search_query/test_constructor.py
@@ -10,7 +10,7 @@ class TestDataRetention(TestCase):
     def setUp(self):
         self.query = SearchQuery(
             "Finger To the Bone",
-            item_type="track",
+            item_types="track",
             filters={
                 "artist": "Brown Bird",
                 "album": "Salt For Salt"
@@ -19,7 +19,7 @@ class TestDataRetention(TestCase):
         )
 
     def test_item_types_saved(self):
-        self.assertEqual(self.query.item_type, "track")
+        self.assertEqual(self.query.item_types, ["track"])
 
     def test_search_saved(self):
         self.assertEqual(self.query.search, "Finger To the Bone")
@@ -39,7 +39,7 @@ class TestDefaults(TestCase):
     def setUp(self):
         self.query = SearchQuery(
             "Finger To the Bone",
-            item_type="track",
+            item_types="track",
         )
 
     def test_filters_saved(self):

--- a/test/spotify/search_query/test_query_str.py
+++ b/test/spotify/search_query/test_query_str.py
@@ -11,7 +11,7 @@ class TestQueryStrValue(TestCase):
 
         self.query = SearchQuery(
             search="foo",
-            item_type="track",
+            item_types="track",
             filters={
                 "artist": "bar",
                 "album": "baz",
@@ -32,7 +32,7 @@ class TestQueryWithEnptyFiltersAndTags(TestCase):
 
         self.query = SearchQuery(
             search="foo",
-            item_type="track",
+            item_types="track",
         )
 
     def test_expected_query_string_received(self):

--- a/test/spotify/search_query/test_raise_on_invalid_item_type.py
+++ b/test/spotify/search_query/test_raise_on_invalid_item_type.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 from custom_components.spotcast.spotify.search_query import (
     SearchQuery,
-    InvalidTagsError,
     InvalidItemTypeError,
 )
 
@@ -14,7 +13,7 @@ class TestValidItemType(TestCase):
     def test_filter(self):
 
         try:
-            SearchQuery.raise_on_invalid_item_type("track")
+            SearchQuery.raise_on_invalid_item_type(["track"])
         except InvalidItemTypeError:
             self.fail()
 
@@ -24,4 +23,4 @@ class TestInvalidItemType(TestCase):
     def test_filter(self):
 
         with self.assertRaises(InvalidItemTypeError):
-            SearchQuery.raise_on_invalid_item_type("invalid")
+            SearchQuery.raise_on_invalid_item_type(["invalid"])

--- a/test/websocket/liked_media_handler/__init__.py
+++ b/test/websocket/liked_media_handler/__init__.py
@@ -1,0 +1,1 @@
+TEST_MODULE = "custom_components.spotcast.websocket.liked_media_handler"

--- a/test/websocket/liked_media_handler/test_async_liked_media.py
+++ b/test/websocket/liked_media_handler/test_async_liked_media.py
@@ -1,19 +1,19 @@
-"""Module to test the async_get_devices function"""
+"""Module to test the async_liked_media function"""
 
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import MagicMock, AsyncMock, patch
 
 from custom_components.spotcast.spotify.account import SpotifyAccount
-from custom_components.spotcast.websocket.devices_handler import (
-    async_get_devices,
+from custom_components.spotcast.websocket.liked_media_handler import (
+    async_liked_media,
     HomeAssistant,
     ActiveConnection,
 )
 
-TEST_MODULE = "custom_components.spotcast.websocket.devices_handler"
+from test.websocket.liked_media_handler import TEST_MODULE
 
 
-class TestDevicesRetrieval(IsolatedAsyncioTestCase):
+class TestBasicLikedMediaRequest(IsolatedAsyncioTestCase):
 
     @patch(f"{TEST_MODULE}.async_get_account")
     async def asyncSetUp(self, mock_account: AsyncMock):
@@ -26,20 +26,15 @@ class TestDevicesRetrieval(IsolatedAsyncioTestCase):
             "account": mock_account.return_value,
         }
 
+        self.mocks["account"].async_liked_songs = AsyncMock(
+            return_value=["foo", "bar", "baz"]
+        )
         self.mocks["account"].id = "12345"
-        self.mocks["account"].async_devices = AsyncMock(return_value=[
-            "foo",
-            "bar",
-            "baz",
-        ])
 
-        await async_get_devices(
+        await async_liked_media(
             self.mocks["hass"],
             self.mocks["connection"],
-            {
-                "id": 1,
-                "type": "spotcast/devices",
-            }
+            {"id": 1},
         )
 
     def test_proper_result_sent(self):
@@ -49,7 +44,7 @@ class TestDevicesRetrieval(IsolatedAsyncioTestCase):
                 {
                     "total": 3,
                     "account": "12345",
-                    "devices": ["foo", "bar", "baz"]
+                    "tracks": ["foo", "bar", "baz"],
                 }
             )
         except AssertionError:

--- a/test/websocket/search_handler/test_async_search_handler.py
+++ b/test/websocket/search_handler/test_async_search_handler.py
@@ -3,46 +3,51 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, AsyncMock, patch
 
-from homeassistant.config_entries import ConfigEntry
-
+from custom_components.spotcast.spotify.account import SpotifyAccount
 from custom_components.spotcast.websocket.search_handler import (
     async_search_handler,
     HomeAssistant,
     ActiveConnection,
-    SpotifyAccount,
 )
 
 TEST_MODULE = "custom_components.spotcast.websocket.search_handler"
 
-class TestSearchHandler(IsolatedAsyncioTestCase):
+
+class TestBaseSearchResult(IsolatedAsyncioTestCase):
     SEARCH_RESULTS = [
         {
             "id": "1A",
             "name": "foo",
-            "href": "https://some.test.url",
-            "images": [{"url": "https://some.icon.jpeg"}],
+            "description": "Foo Playlists",
+            "uri": "spotify:playlist:foo",
+            "images": [
+                {"url": "https://some.icon.jpeg", "height": 64, "width": 64},
+            ],
         },
         {
             "id": "1B",
             "name": "bar",
             "href": "https://some.test2.url",
-            "images": [{"url": "https://some.icon2.jpeg"}],
+            "uri": "spotify:playlist:bar",
+            "images": [
+                {"url": "https://some.icon2.jpeg", "height": 64, "width": 64},
+            ],
         },
         {
             "id": "1C",
-            "name": "BAZ",
+            "name": "baz",
             "href": "https://some.test3.url",
-            "images": [{"url": "https://some.icon3.jpeg"}],
+            "uri": "spotify:playlist:baz",
+            "images": [
+                {"url": "https://some.icon3.jpeg", "height": 64, "width": 64},
+            ],
         },
     ]
 
-    @patch(f"{TEST_MODULE}.search_account", new_callable=MagicMock)
-    @patch.object(SpotifyAccount, "async_from_config_entry")
-    async def asyncSetUp(self, mock_account: AsyncMock, mock_search_account: MagicMock):
-        """Set up mocks for async_search_handler tests."""
+    @patch(f"{TEST_MODULE}.async_get_account")
+    async def asyncSetUp(self, mock_account: AsyncMock):
 
         mock_account.return_value = MagicMock(spec=SpotifyAccount)
-        mock_search_account.return_value = mock_account.return_value
 
         self.mocks = {
             "hass": MagicMock(spec=HomeAssistant),
@@ -50,95 +55,49 @@ class TestSearchHandler(IsolatedAsyncioTestCase):
             "account": mock_account.return_value,
         }
 
-        self.mocks["account"].async_search = AsyncMock()
-        self.mocks["account"].async_search.return_value = {"playlists": self.SEARCH_RESULTS}
-
-    async def test_playlist_search(self):
-        """Test search handler for playlists."""
-        await async_search_handler(
-            self.mocks["hass"],
-            self.mocks["connection"],
-            {
-                "id": 1,
-                "type": "spotcast/search",
-                "query": "my query",
-                "searchType": "playlist",
-                "limit": 3,
-                "account": "12345",
-            },
+        self.mocks["account"].async_search = AsyncMock(
+            return_value={"playlists": self.SEARCH_RESULTS}
         )
 
-        self.mocks["connection"].send_result.assert_called_with(
-            1,
-            {
-                "total": 3,
-                "account": "12345",
-                "playlists": [
-                    {
-                        "id": "1A",
-                        "name": "foo",
-                        "href": "https://some.test.url",
-                        "icon": "https://some.icon.jpeg",
-                    },
-                    {
-                        "id": "1B",
-                        "name": "bar",
-                        "href": "https://some.test2.url",
-                        "icon": "https://some.icon2.jpeg",
-                    },
-                    {
-                        "id": "1C",
-                        "name": "BAZ",
-                        "href": "https://some.test3.url",
-                        "icon": "https://some.icon3.jpeg",
-                    },
-                ],
-            },
-        )
-
-    async def test_track_search(self):
-        """Test search handler for tracks."""
-        self.mocks["account"].async_search.return_value = {
-            "tracks": self.SEARCH_RESULTS
-        }
+        self.mocks["account"].id = "12345"
 
         await async_search_handler(
             self.mocks["hass"],
             self.mocks["connection"],
-            {
-                "id": 2,
-                "type": "spotcast/search",
-                "query": "another query",
-                "searchType": "track",
-                "limit": 3,
-                "account": "12345",
-            },
+            {"id": 1, "query": "foo"}
         )
 
-        self.mocks["connection"].send_result.assert_called_with(
-            2,
-            {
-                "total": 3,
-                "account": "12345",
-                "tracks": [
-                    {
-                        "id": "1A",
-                        "name": "foo",
-                        "href": "https://some.test.url",
-                        "icon": "https://some.icon.jpeg",
-                    },
-                    {
-                        "id": "1B",
-                        "name": "bar",
-                        "href": "https://some.test2.url",
-                        "icon": "https://some.icon2.jpeg",
-                    },
-                    {
-                        "id": "1C",
-                        "name": "BAZ",
-                        "href": "https://some.test3.url",
-                        "icon": "https://some.icon3.jpeg",
-                    },
-                ],
-            },
-        )
+    def tests_send_result_properly_called(self):
+        try:
+            self.mocks["connection"].send_result.assert_called_with(
+                1,
+                {
+                    "total": 3,
+                    "account": "12345",
+                    "playlists": [
+                        {
+                            "id": "1A",
+                            "name": "foo",
+                            "uri": "spotify:playlist:foo",
+                            "description": "Foo Playlists",
+                            "icon": "https://some.icon.jpeg"
+                        },
+                        {
+                            "id": "1B",
+                            "name": "bar",
+                            "uri": "spotify:playlist:bar",
+                            "description": None,
+                            "icon": "https://some.icon2.jpeg"
+                        },
+                        {
+                            "id": "1C",
+                            "name": "baz",
+                            "uri": "spotify:playlist:baz",
+                            "description": None,
+                            "icon": "https://some.icon3.jpeg"
+                        },
+                    ]
+                }
+            )
+        except AssertionError:
+            self.fail()

--- a/test/websocket/test_async_setup_websocket.py
+++ b/test/websocket/test_async_setup_websocket.py
@@ -26,5 +26,5 @@ class TestHandlerRegistration(IsolatedAsyncioTestCase):
 
         await async_setup_websocket(self.mocks["hass"])
 
-    def test_6_handlers_registered(self):
-        self.assertEqual(self.mocks["register"].call_count, 6)
+    def test_10_handlers_registered(self):
+        self.assertEqual(self.mocks["register"].call_count, 10)

--- a/test/websocket/tracks_handler/__init__.py
+++ b/test/websocket/tracks_handler/__init__.py
@@ -1,0 +1,1 @@
+TEST_MODULE = "custom_components.spotcast.websocket.tracks_handler"

--- a/test/websocket/tracks_handler/test_async_tracks_handler.py
+++ b/test/websocket/tracks_handler/test_async_tracks_handler.py
@@ -1,0 +1,113 @@
+"""Module to test the async_tracks_handler function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from custom_components.spotcast.spotify.account import SpotifyAccount
+from custom_components.spotcast.websocket.tracks_handler import (
+    async_tracks_handler,
+    HomeAssistant,
+    ActiveConnection,
+)
+
+from test.websocket.tracks_handler import TEST_MODULE
+
+
+class TestBasicRequest(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_get_account")
+    async def asyncSetUp(self, mock_account: AsyncMock):
+
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "connection": MagicMock(spec=ActiveConnection),
+            "account": mock_account.return_value,
+        }
+
+        self.mocks["account"].id = "12345"
+        self.mocks["account"].async_get_playlist_tracks = AsyncMock(
+            return_value=[
+                {
+                    "track": {
+                        "id": "foo",
+                        "name": "Foo",
+                        "uri": "spotify:track:foo",
+                        "album": {"uri": "spotify:album:foo"},
+                        "artists": [
+                            {"uri": "spotify:artist:foo"}
+                        ]
+                    }
+                },
+                {
+                    "track": {
+                        "id": "bar",
+                        "name": "Bar",
+                        "uri": "spotify:track:bar",
+                        "album": {"uri": "spotify:album:bar"},
+                        "artists": [
+                            {"uri": "spotify:artist:bar"}
+                        ]
+                    }
+                },
+                {
+                    "track": {
+                        "id": "baz",
+                        "name": "Baz",
+                        "uri": "spotify:track:baz",
+                        "album": {"uri": "spotify:album:baz"},
+                        "artists": [
+                            {"uri": "spotify:artist:baz"}
+                        ]
+                    }
+                },
+            ],
+        )
+
+        await async_tracks_handler(
+            self.mocks["hass"],
+            self.mocks["connection"],
+            {"id": 1, "playlist_id": "spotify:playlist:foo"}
+        )
+
+    def test_result_properly_sent(self):
+        try:
+            self.mocks["connection"].send_result.assert_called_with(
+                1,
+                {
+                    "total": 3,
+                    "account": "12345",
+                    "tracks": [
+                        {
+                            "id": "foo",
+                            "name": "Foo",
+                            "uri": "spotify:track:foo",
+                            "album": {"uri": "spotify:album:foo"},
+                            "artists": [
+                                {"uri": "spotify:artist:foo"}
+                            ]
+                        },
+                        {
+                            "id": "bar",
+                            "name": "Bar",
+                            "uri": "spotify:track:bar",
+                            "album": {"uri": "spotify:album:bar"},
+                            "artists": [
+                                {"uri": "spotify:artist:bar"}
+                            ]
+                        },
+                        {
+                            "id": "baz",
+                            "name": "Baz",
+                            "uri": "spotify:track:baz",
+                            "album": {"uri": "spotify:album:baz"},
+                            "artists": [
+                                {"uri": "spotify:artist:baz"}
+                            ]
+                        },
+                    ]
+                }
+            )
+        except AssertionError:
+            self.fail()

--- a/test/websocket/utils/test_async_get_account.py
+++ b/test/websocket/utils/test_async_get_account.py
@@ -1,0 +1,66 @@
+"""Module to test the async_get_account"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from custom_components.spotcast.websocket.utils import (
+    async_get_account,
+    HomeAssistant,
+    SpotifyAccount,
+)
+
+TEST_MODULE = "custom_components.spotcast.websocket.utils"
+
+
+class TestAccountIdProvided(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    @patch(f"{TEST_MODULE}.search_account", new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_search: MagicMock,
+        mock_account: AsyncMock,
+        mock_entry: MagicMock,
+    ):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "search": mock_search,
+            "account": mock_account,
+        }
+
+        await async_get_account(self.mocks["hass"], "12345")
+
+    def test_search_called(self):
+        try:
+            self.mocks["search"].assert_called()
+        except AssertionError:
+            self.fail()
+
+
+class TestAccountIdNotProvided(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    @patch(f"{TEST_MODULE}.search_account", new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_search: MagicMock,
+        mock_account: AsyncMock,
+        mock_entry: MagicMock,
+    ):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "search": mock_search,
+            "account": mock_account,
+        }
+
+        await async_get_account(self.mocks["hass"])
+
+    def test_async_from_config_called(self):
+        try:
+            self.mocks["account"].assert_called()
+        except AssertionError:
+            self.fail()

--- a/test/websocket/view_handler/test_async_view_handler.py
+++ b/test/websocket/view_handler/test_async_view_handler.py
@@ -1,0 +1,125 @@
+"""Module to test the async_view_handler function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from custom_components.spotcast.spotify.account import SpotifyAccount
+from custom_components.spotcast.websocket.view_handler import (
+    async_view_handler,
+    HomeAssistant,
+    ActiveConnection,
+)
+
+TEST_MODULE = "custom_components.spotcast.websocket.view_handler"
+
+
+class TestViewQuery(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_get_account")
+    async def asyncSetUp(self, mock_account: AsyncMock):
+
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "connection": MagicMock(spec=ActiveConnection),
+            "account": mock_account.return_value,
+        }
+
+        self.mocks["account"].id = "12345"
+        self.mocks["account"].async_view = AsyncMock(return_value=[
+            {
+                "id": "foo",
+                "name": "Foo",
+                "uri": "spotify:playlist:foo",
+                "description": "Playlist Foo",
+                "images": [
+                    {
+                        "url": "https://some.icon1.jpeg",
+                        "height": 64,
+                        "width": 64,
+                    }
+                ]
+            },
+            {
+                "id": "bar",
+                "name": "Bar",
+                "uri": "spotify:playlist:bar",
+                "description": "Playlist Bar",
+                "images": [
+                    {
+                        "url": "https://some.icon2.jpeg",
+                        "height": 64,
+                        "width": 64,
+                    }
+                ]
+            },
+            {
+                "id": "baz",
+                "name": "Baz",
+                "uri": "spotify:playlist:baz",
+                "description": "Playlist Baz",
+                "images": [
+                    {
+                        "url": "https://some.icon3.jpeg",
+                        "height": 64,
+                        "width": 64,
+                    }
+                ]
+            },
+        ])
+
+        await async_view_handler(
+            self.mocks["hass"],
+            self.mocks["connection"],
+            {
+                "id": 1,
+                "type": "spotcast/view",
+                "name": "made-for-x",
+            }
+        )
+
+    def test_async_view_properly_called(self):
+        try:
+            self.mocks["account"].async_view.assert_called_with(
+                url="views/made-for-x",
+                language=None,
+                limit=None,
+            )
+        except AssertionError:
+            self.fail()
+
+    def test_proper_result_sent(self):
+        try:
+            self.mocks["connection"].send_result.assert_called_with(
+                1,
+                {
+                    "total": 3,
+                    "account": "12345",
+                    "playlists": [
+                        {
+                            "id": "foo",
+                            "name": "Foo",
+                            "uri": "spotify:playlist:foo",
+                            "description": "Playlist Foo",
+                            "icon": "https://some.icon1.jpeg"
+                        },
+                        {
+                            "id": "bar",
+                            "name": "Bar",
+                            "uri": "spotify:playlist:bar",
+                            "description": "Playlist Bar",
+                            "icon": "https://some.icon2.jpeg"
+                        },
+                        {
+                            "id": "baz",
+                            "name": "Baz",
+                            "uri": "spotify:playlist:baz",
+                            "description": "Playlist Baz",
+                            "icon": "https://some.icon3.jpeg"
+                        },
+                    ]
+                }
+            )
+        except AssertionError:
+            self.fail()


### PR DESCRIPTION
Hi @mikevanes,

I wrote the tests for your new endpoints and also refactored a few elements to fit with the structure of the library. Mostly:

- Service `like_media` expects a config key and won't allow account search. I want to force by design to go through config ids for services
- `async_view` allows for no limit fetching by default. I want to keep the `SpotifyAccount` out of implementation. If its technically possible to get an unlimited amount of playlist in a view, we should allow it and let the implementation decide on the limit
- `async_view` expects a `language` argument instead of a `locale`. Since the country is available in the account, we should make sure to align with the country of the spotify account and deal with language at the front end level. This allow to pass a language and the function takes care of making a valid `locale`.
- websocket `spotcast/view` also default to unlimited items. The front end implementation should decide on its own limit.
- websocket `spotcast/view` now expect an argument `name` instead of `url` since the information requested wasn't an actual url, but the name of the view that would be fetched.
- websocket `spotcast/tracks` now expects `playlist_id` instead of `playlistId` do normalize to the naming scheme of the project.

Also to note, if we want to make some improvements:

- `SeachQuery` now allows for multiple item_types, maybe we would want to leverage that for Spotify-Card. I'll let you decide. We could make the change in the websocket handler

Finally, we will need documentation on the new websocket endpoints and services. Please make sure to include them and to follow the format from other documentation pages